### PR TITLE
Python Syntax Error: Close parens in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,4 +20,4 @@ setup(
     description='A web app that serves files out of your IBM Object Storage',
     long_description=long_description,
     url='https://github.com/ibm-cds-labs/openobjectstore',
-    license='Apache-2.0'
+    license='Apache-2.0')


### PR DESCRIPTION
flake8 testing of https://github.com/ibm-watson-data-lab/openobjectstore on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./server.py:69:91: F821 undefined name 'filename'
        return MakeJSONMsgResponse({"message":ce.msg,"containername":container,"filename":filename}, 404)
                                                                                          ^
./setup.py:23:24: E999 SyntaxError: unexpected EOF while parsing
    license='Apache-2.0'
                       ^
1     E999 SyntaxError: unexpected EOF while parsing
1     F821 undefined name 'filename'
2
```
@rajrsingh